### PR TITLE
Replace disallowed service fetching in FileController with type-hints

### DIFF
--- a/Controller/FileController.php
+++ b/Controller/FileController.php
@@ -7,11 +7,15 @@
 
 namespace CuriousInc\FileUploadFormTypeBundle\Controller;
 
+use CuriousInc\FileUploadFormTypeBundle\Exception\InvalidFileNameException;
 use CuriousInc\FileUploadFormTypeBundle\Exception\NotImplementedException;
+use CuriousInc\FileUploadFormTypeBundle\Namer\FileNamer;
+use CuriousInc\FileUploadFormTypeBundle\Service\ClassHelper;
 use FOS\RestBundle\Controller\Annotations as Rest;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Oneup\UploaderBundle\Uploader\Storage\FilesystemOrphanageStorage;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -40,11 +44,14 @@ class FileController extends RestController
      *
      * @param Request $request
      *
+     * @param FilesystemOrphanageStorage $orphanageStorage
+     * @param FileNamer $fileNamer
      * @return Response|HttpException
      *
+     * @throws InvalidFileNameException
      * @Rest\Post("/deleteSessionFile")
      */
-    public function deleteSessionFileAction(Request $request)
+    public function deleteSessionFileAction(Request $request, FilesystemOrphanageStorage $orphanageStorage, FileNamer $fileNamer)
     {
         $name = (string)$request->get('name');
 
@@ -54,14 +61,11 @@ class FileController extends RestController
         }
 
         // Get current temporary files from orphanage manager
-        /** @var FilesystemOrphanageStorage $manager */
-        $manager = $this->get('oneup_uploader.orphanage_manager')->get('gallery');
-        $files = $manager->getFiles();
-        $namer = $this->get('curious_file_upload.file_namer');
-        /** @var \Symfony\Component\Finder\SplFileInfo $file */
+        $files = $orphanageStorage->getFiles();
+        /** @var SplFileInfo $file */
         foreach ($files as $file) {
             // Delete temporary file with given filename
-            if ($file->getRelativePathname() === $namer->convertUnderscorePath($name)) {
+            if ($file->getRelativePathname() === $fileNamer->convertUnderscorePath($name)) {
                 $fs = new Filesystem();
                 $fs->remove($file);
 
@@ -94,14 +98,14 @@ class FileController extends RestController
      *
      * @param Request $request
      *
+     * @param ClassHelper $classHelper
      * @return Response|HttpException
      *
      * @Rest\Post("/deletePersistedFile")
      */
-    public function deletePersistedFileAction(Request $request)
+    public function deletePersistedFileAction(Request $request, ClassHelper $classHelper)
     {
         $em = $this->getDoctrine()->getManager();
-        $classHelper = $this->get('curious_file_upload.service.class_helper');
 
         $id = (int)$request->get('id');
         $sourceEntityId = (string)$request->get('sourceEntityId');

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,7 +1,7 @@
 curious_file_upload_delete_temporary:
     path: /upload/session/files/delete
-    defaults: { _controller: CuriousIncFileUploadFormTypeBundle:File:deleteSessionFile }
+    defaults: { _controller: CuriousInc\FileUploadFormTypeBundle\Controller\FileController::deleteSessionFileAction }
 
 curious_file_upload_delete_persisted:
     path: /upload/persisted/files/delete
-    defaults: { _controller: CuriousIncFileUploadFormTypeBundle:File:deletePersistedFile }
+    defaults: { _controller: CuriousInc\FileUploadFormTypeBundle\Controller\FileController::deletePersistedFileAction }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,4 +1,8 @@
 services:
+  CuriousInc\FileUploadFormTypeBundle\Controller\FileController:
+    public: true
+    tags: ['controller.service_arguments']
+
   curious_file_upload.dropzone_type:
     class: CuriousInc\FileUploadFormTypeBundle\Form\Type\DropzoneType
     arguments:
@@ -32,10 +36,12 @@ services:
     arguments:
       - '@oneup_uploader.orphanage_manager'
 
-  curious_file_upload.service.class_helper:
-    class: CuriousInc\FileUploadFormTypeBundle\Service\ClassHelper
+  CuriousInc\FileUploadFormTypeBundle\Service\ClassHelper:
     arguments:
       - '@curious_file_upload.service.annotation_helper'
+
+  curious_file_upload.service.class_helper:
+    alias: CuriousInc\FileUploadFormTypeBundle\Service\ClassHelper
 
   curious_file_upload.service.annotation_helper:
     class: CuriousInc\FileUploadFormTypeBundle\Service\AnnotationHelper
@@ -46,7 +52,7 @@ services:
     class: CuriousInc\FileUploadFormTypeBundle\Migration\MediaBundleMigrator
     arguments:
       - '@service_container'
-      - '@doctrine.orm.entity_manager'
+      - '@doctrine.orm.entity_manager)'
       - '@curious_file_upload.file_namer'
       - '@curious_file_upload.service.annotation_helper'
       - '@curious_file_upload.service.class_helper'


### PR DESCRIPTION
Symfony 4 does not allow fetching private services from the service container anymore, which lead to a number of issues while trying to delete files. For that reason, `container->get()` statements have been phased out in the `FileController` and replaced with argument type-hinting.